### PR TITLE
added quoting of dbname in queries

### DIFF
--- a/src/InfluxDB/Database.php
+++ b/src/InfluxDB/Database.php
@@ -86,7 +86,7 @@ class Database
     {
         try {
             $query = sprintf(
-                'CREATE DATABASE %s%s',
+                'CREATE DATABASE %s"%s"',
                 ($createIfNotExists ? 'IF NOT EXISTS ' : ''),
                 $this->name
             );
@@ -169,7 +169,7 @@ class Database
      */
     public function listRetentionPolicies()
     {
-        return $this->query(sprintf('SHOW RETENTION POLICIES ON %s', $this->name))->getPoints();
+        return $this->query(sprintf('SHOW RETENTION POLICIES ON "%s"', $this->name))->getPoints();
     }
 
     /**
@@ -177,7 +177,7 @@ class Database
      */
     public function drop()
     {
-        $this->query(sprintf('DROP DATABASE %s', $this->name));
+        $this->query(sprintf('DROP DATABASE "%s"', $this->name));
     }
 
     /**
@@ -206,7 +206,7 @@ class Database
     protected function getRetentionPolicyQuery($method, RetentionPolicy $retentionPolicy)
     {
         $query = sprintf(
-            '%s RETENTION POLICY %s ON %s DURATION %s REPLICATION %s',
+            '%s RETENTION POLICY %s ON "%s" DURATION %s REPLICATION %s',
             $method,
             $retentionPolicy->name,
             $this->name,

--- a/src/InfluxDB/Database.php
+++ b/src/InfluxDB/Database.php
@@ -206,7 +206,7 @@ class Database
     protected function getRetentionPolicyQuery($method, RetentionPolicy $retentionPolicy)
     {
         $query = sprintf(
-            '%s RETENTION POLICY %s ON "%s" DURATION %s REPLICATION %s',
+            '%s RETENTION POLICY "%s" ON "%s" DURATION %s REPLICATION %s',
             $method,
             $retentionPolicy->name,
             $this->name,

--- a/src/InfluxDB/Query/Builder.php
+++ b/src/InfluxDB/Query/Builder.php
@@ -255,7 +255,7 @@ class Builder
      */
     protected function parseQuery()
     {
-        $query = sprintf("SELECT %s FROM %s", $this->selection, $this->metric);
+        $query = sprintf('SELECT %s FROM "%s"', $this->selection, $this->metric);
 
         if (! $this->metric) {
             throw new \InvalidArgumentException('No metric provided to from()');

--- a/tests/unit/DatabaseTest.php
+++ b/tests/unit/DatabaseTest.php
@@ -53,7 +53,7 @@ class DatabaseTest extends AbstractTest
         $this->assertEquals($this->database->query('SELECT * FROM test_metric'), $testResultSet);
 
         $this->database->drop();
-        $this->assertEquals('DROP DATABASE influx_test_db', Client::$lastQuery);
+        $this->assertEquals('DROP DATABASE "influx_test_db"', Client::$lastQuery);
 
     }
 
@@ -68,11 +68,11 @@ class DatabaseTest extends AbstractTest
         );
 
         $this->database->listRetentionPolicies();
-        $this->assertEquals('SHOW RETENTION POLICIES ON influx_test_db', Client::$lastQuery);
+        $this->assertEquals('SHOW RETENTION POLICIES ON "influx_test_db"', Client::$lastQuery);
 
         $this->database->alterRetentionPolicy($this->getTestRetentionPolicy());
         $this->assertEquals(
-            'ALTER RETENTION POLICY test ON influx_test_db DURATION 1d REPLICATION 1 DEFAULT',
+            'ALTER RETENTION POLICY "test" ON "influx_test_db" DURATION 1d REPLICATION 1 DEFAULT',
             Client::$lastQuery
         );
     }
@@ -90,17 +90,17 @@ class DatabaseTest extends AbstractTest
         // test create with retention policy
         $this->database->create($this->getTestRetentionPolicy('influx_test_db'), true);
         $this->assertEquals(
-            'CREATE RETENTION POLICY influx_test_db ON influx_test_db DURATION 1d REPLICATION 1 DEFAULT',
+            'CREATE RETENTION POLICY "influx_test_db" ON "influx_test_db" DURATION 1d REPLICATION 1 DEFAULT',
             Client::$lastQuery
         );
 
         // test creating a database without create if not exists
         $this->database->create(null, true);
-        $this->assertEquals('CREATE DATABASE IF NOT EXISTS influx_test_db', Client::$lastQuery);
+        $this->assertEquals('CREATE DATABASE IF NOT EXISTS "influx_test_db"', Client::$lastQuery);
 
         // test creating a database without create if not exists
         $this->database->create(null, false);
-        $this->assertEquals('CREATE DATABASE influx_test_db', Client::$lastQuery);
+        $this->assertEquals('CREATE DATABASE "influx_test_db"', Client::$lastQuery);
 
 
         $this->mockClient->expects($this->any())


### PR DESCRIPTION
Some queries fail if DB or measurement name is a reserved keyword.
Example: CREATE DATABASE stats
Simple quoting of the names solves this problem.