### PR TITLE
Escape field values as per line protocol

### DIFF
--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -82,10 +82,10 @@ class Point
         $string = $this->measurement;
 
         if (count($this->tags) > 0) {
-            $string .=  ',' . $this->arrayToString($this->escapeCharacters($this->tags));
+            $string .=  ',' . $this->arrayToString($this->escapeTags($this->tags));
         }
 
-        $string .= ' ' . $this->arrayToString($this->escapeCharacters($this->fields));
+        $string .= ' ' . $this->arrayToString($this->escapeFields($this->fields));
 
         if ($this->timestamp) {
             $string .= ' '.$this->timestamp;
@@ -143,7 +143,7 @@ class Point
             if (is_integer($field)) {
                 $field = sprintf('%di', $field);
             } elseif (is_string($field)) {
-                $field = sprintf("\"%s\"", $field);
+                $field = $this->escapeFieldValue($field);
             } elseif (is_bool($field)) {
                 $field = ($field ? "true" : "false");
             }
@@ -174,7 +174,7 @@ class Point
      * @param array $arr
      * @return array
      */
-    private function escapeCharacters(array $arr)
+    private function escapeTags(array $arr)
     {
         $returnArr = [];
 
@@ -183,6 +183,35 @@ class Point
         }
 
         return $returnArr;
+    }
+
+    /**
+     * Escapes invalid characters in field keys and values
+     *
+     * @param array $arr
+     * @return array
+     */
+    private function escapeFields(array $arr)
+    {
+        $returnArr = [];
+
+        foreach($arr as $key => $value) {
+            $returnArr[$this->addSlashes($key)] = $value;
+        }
+
+        return $returnArr;
+    }
+
+    /*
+     * Returns string double-quoted and double-quotes escaped per Influx write protocol syntax
+     *
+     * @param string $value
+     * @return string
+     */
+    private function escapeFieldValue($value)
+    {
+        $escapedValue = str_replace('"', '\"', $value);
+        return sprintf('"%s"', $escapedValue);
     }
 
     /**
@@ -244,7 +273,5 @@ class Point
         }
 
         return true;
-
-
     }
 }

--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -82,10 +82,10 @@ class Point
         $string = $this->measurement;
 
         if (count($this->tags) > 0) {
-            $string .=  ',' . $this->arrayToString($this->escapeTags($this->tags));
+            $string .=  ',' . $this->arrayToString($this->escapeCharacters($this->tags, true));
         }
 
-        $string .= ' ' . $this->arrayToString($this->escapeFields($this->fields));
+        $string .= ' ' . $this->arrayToString($this->escapeCharacters($this->fields, false));
 
         if ($this->timestamp) {
             $string .= ' '.$this->timestamp;
@@ -169,34 +169,18 @@ class Point
     }
 
     /**
-     * Escapes invalid characters in both the array key and array value
+     * Escapes invalid characters in both the array key and optionally the array value
      *
      * @param array $arr
+     * @param bool $escapeValues
      * @return array
      */
-    private function escapeTags(array $arr)
+    private function escapeCharacters(array $arr, $escapeValues)
     {
         $returnArr = [];
 
         foreach ($arr as $key => $value) {
-            $returnArr[$this->addSlashes($key)] = $this->addSlashes($value);
-        }
-
-        return $returnArr;
-    }
-
-    /**
-     * Escapes invalid characters in field keys and values
-     *
-     * @param array $arr
-     * @return array
-     */
-    private function escapeFields(array $arr)
-    {
-        $returnArr = [];
-
-        foreach($arr as $key => $value) {
-            $returnArr[$this->addSlashes($key)] = $value;
+            $returnArr[$this->addSlashes($key)] = $escapeValues ? $this->addSlashes($value) : $value;
         }
 
         return $returnArr;

--- a/tests/unit/PointTest.php
+++ b/tests/unit/PointTest.php
@@ -74,6 +74,15 @@ class PointTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testFieldValueStringEscaping()
+    {
+        $expected = 'instance,host=server01,region=us-west spaces="string with spaces",doublequote="the \" is escaped"';
+        $point = $this->getPoint(null);
+
+        $point->setFields(['spaces' => 'string with spaces', 'doublequote' => 'the " is escaped']);
+
+        $this->assertEquals($expected, (string) $point);
+    }
 
     /**
      * Provide wrong timestamp value for testing.


### PR DESCRIPTION
Hi

I noticed that field values with spaces in had extra backslashes before the spaces and double-quotes were not getting escaped.

Checked the [documentation](https://docs.influxdata.com/influxdb/v0.10/write_protocols/write_syntax/#data-types) and it appears to be a bug, so I've created a PR.

### Steps to reproduce

Write a point with a field value with spaces in.

````
$points = [
    new Point(
        'test_metric',
        null,
        ['host' => 'server01', 'region' => 'us-west'],
        ['testfield' => 'field with spaces'],
        exec('date +%s%N')
    )
];
$result = $database->writePoints($points);
```

You should see the testfield field has the value "field\ with\ spaces"