### PR TITLE
Make Guzzle dependency optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,10 @@
     ],
     "require": {
         "php": "^5.5 | ^7.0",
-        "guzzlehttp/guzzle": "6.*",
         "symfony/event-dispatcher": "2.*|3.*"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": "Allows using the HTTP driver"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",


### PR DESCRIPTION
Currently `guzzlehttp/guzzle:6.*` dependency is mandatory to install even if you are going to use UDP transport. This makes the library impossible to use with projects which already use older versions of Guzzle. 

This PR makes the Guzzle dependency optional.