### PR TITLE
Updating Influx Database with support for writing direct payloads + Minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 .idea
 build/
 test.php
+.project

--- a/src/InfluxDB/Client.php
+++ b/src/InfluxDB/Client.php
@@ -267,7 +267,7 @@ class Client
      * @param  int    $timeout
      * @param  bool   $verifySSL
      *
-*@return Client|Database
+     * @return Client|Database
      * @throws ClientException
      */
     public static function fromDSN($dsn, $timeout = 0, $verifySSL = false)

--- a/src/InfluxDB/Client.php
+++ b/src/InfluxDB/Client.php
@@ -205,8 +205,8 @@ class Client
     /**
      * Write data
      *
-     * @param array           $parameters
-     * @param string          $payload
+     * @param array        $parameters
+     * @param string|array $payload     InfluxDB payload (Or array of payloads) that conform to the Line syntax.
      *
      * @return bool
      */
@@ -224,7 +224,11 @@ class Client
         $driver->setParameters($parameters);
 
         // send the points to influxDB
-        $driver->write(implode("\n", $payload));
+        if (is_array($payload)) {
+            $driver->write(implode("\n", $payload));
+        } else {
+            $driver->write($payload);
+        }
 
         return $driver->isSuccess();
     }

--- a/src/InfluxDB/Database.php
+++ b/src/InfluxDB/Database.php
@@ -151,12 +151,12 @@ class Database
      *   2) Inserting very large set of points into a measurement where looping via array_map() actually
      *      hurts performance as the payload may be calculated in advance by caller.
      *
-     * @param  string      $payload          InfluxDB payload that conforms to the Line syntax.
-     * @param  string      $precision        The timestamp precision (defaults to nanoseconds).
-     * @param  string|null $retentionPolicy  Specifies an explicit retention policy to use when writing all points. If
-     *                                       not set, the default retention period will be used. This is only
-     *                                       applicable for the Guzzle driver. The UDP driver utilizes the endpoint
-     *                                       configuration defined in the server's influxdb configuration file.
+     * @param  string|array  $payload          InfluxDB payload (Or array of payloads) that conform to the Line syntax.
+     * @param  string        $precision        The timestamp precision (defaults to nanoseconds).
+     * @param  string|null   $retentionPolicy  Specifies an explicit retention policy to use when writing all points. If
+     *                                         not set, the default retention period will be used. This is only
+     *                                         applicable for the Guzzle driver. The UDP driver utilizes the endpoint
+     *                                         configuration defined in the server's influxdb configuration file.
      * @return bool
      * @throws \InfluxDB\Exception
      */

--- a/src/InfluxDB/Database.php
+++ b/src/InfluxDB/Database.php
@@ -119,12 +119,15 @@ class Database
     }
 
     /**
-     * Writes points into InfluxDB
+     * Write points into InfluxDB using the current driver. This is the recommended method for inserting
+     * data into InfluxDB.
      *
      * @param  Point[]     $points           Array of Point objects
-     * @param  string      $precision        The timestamp precision (defaults to nanoseconds)
+     * @param  string      $precision        The timestamp precision (defaults to nanoseconds).
      * @param  string|null $retentionPolicy  Specifies an explicit retention policy to use when writing all points. If
-     *                                       not set, the default retention period will be used.
+     *                                       not set, the default retention period will be used. This is only
+     *                                       applicable for the Guzzle driver. The UDP driver utilizes the endpoint
+     *                                       configuration defined in the server's influxdb configuration file.
      * @return bool
      * @throws \InfluxDB\Exception
      */
@@ -137,6 +140,28 @@ class Database
             $points
         );
 
+        return $this->writePayload($payload, $precision, $retentionPolicy);
+    }
+
+    /**
+     * Write a payload into InfluxDB using the current driver. This method is similar to <tt>writePoints()</tt>,
+     * except it takes a string payload instead of an array of Points. This is useful in the following situations:
+     *
+     *   1) Performing unique queries that may not conform to the current Point standard.
+     *   2) Inserting very large set of points into a measurement where looping via array_map() actually
+     *      hurts performance as the payload may be calculated in advance by caller.
+     *
+     * @param  string      $payload          InfluxDB payload that conforms to the Line syntax.
+     * @param  string      $precision        The timestamp precision (defaults to nanoseconds).
+     * @param  string|null $retentionPolicy  Specifies an explicit retention policy to use when writing all points. If
+     *                                       not set, the default retention period will be used. This is only
+     *                                       applicable for the Guzzle driver. The UDP driver utilizes the endpoint
+     *                                       configuration defined in the server's influxdb configuration file.
+     * @return bool
+     * @throws \InfluxDB\Exception
+     */
+    public function writePayload($payload, $precision = self::PRECISION_NANOSECONDS, $retentionPolicy = null)
+    {
         try {
             $parameters = [
                 'url' => sprintf('write?db=%s&precision=%s', $this->name, $precision),

--- a/src/InfluxDB/Driver/Guzzle.php
+++ b/src/InfluxDB/Driver/Guzzle.php
@@ -7,8 +7,6 @@ namespace InfluxDB\Driver;
 
 use GuzzleHttp\Client;
 use Guzzle\Http\Message\Response;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Psr7\Request;
 use InfluxDB\ResultSet;
 
 /**

--- a/src/InfluxDB/Driver/UDP.php
+++ b/src/InfluxDB/Driver/UDP.php
@@ -5,8 +5,6 @@
 
 namespace InfluxDB\Driver;
 
-use Symfony\Component\Config\Definition\Exception\Exception;
-
 /**
  * Class UDP
  *
@@ -27,6 +25,12 @@ class UDP implements DriverInterface
     private $config;
 
     /**
+     *
+     * @var resource
+     */
+    private $stream;
+
+    /**
      * @param string $host IP/hostname of the InfluxDB host
      * @param int    $port Port of the InfluxDB process
      */
@@ -34,24 +38,20 @@ class UDP implements DriverInterface
     {
         $this->config['host'] = $host;
         $this->config['port'] = $port;
-
-
     }
 
     /**
-     * Called by the client write() method, will pass an array of required parameters such as db name
-     *
-     * will contain the following parameters:
-     *
-     * [
-     *  'database' => 'name of the database',
-     *  'url' => 'URL to the resource',
-     *  'method' => 'HTTP method used'
-     * ]
-     *
-     * @param array $parameters
-     *
-     * @return mixed
+     * Close the stream (if created)
+     */
+    public function __destruct()
+    {
+        if (isset($this->stream) && is_resource($this->stream)) {
+            fclose($this->stream);
+        }
+    }
+
+    /**
+     * {@inheritdoc }
      */
     public function setParameters(array $parameters)
     {
@@ -59,7 +59,7 @@ class UDP implements DriverInterface
     }
 
     /**
-     * @return array
+     * {@inheritdoc }
      */
     public function getParameters()
     {
@@ -67,32 +67,36 @@ class UDP implements DriverInterface
     }
 
     /**
-     * Send the data
-     *
-     * @param $data
-     *
-     * @return mixed
+     * {@inheritdoc }
      */
     public function write($data = null)
     {
+        if (isset($this->stream) === false) {
+            $this->createStream();
+        }
 
-        $host = sprintf('udp://%s:%d', $this->config['host'], $this->config['port']);
-
-        // stream the data using UDP and suppress any errors
-        $stream = @stream_socket_client($host);
-        @stream_socket_sendto($stream, $data);
-        @fclose($stream);
+        @stream_socket_sendto($this->stream, $data);
 
         return true;
     }
 
     /**
-     * Should return if sending the data was successful
-     *
-     * @return bool
+     * {@inheritdoc }
      */
     public function isSuccess()
     {
         return true;
     }
+
+    /**
+     * Create the resource stream
+     */
+    protected function createStream()
+    {
+        $host = sprintf('udp://%s:%d', $this->config['host'], $this->config['port']);
+
+        // stream the data using UDP and suppress any errors
+        $this->stream = @stream_socket_client($host);
+    }
+
 }

--- a/src/InfluxDB/Driver/UDP.php
+++ b/src/InfluxDB/Driver/UDP.php
@@ -51,7 +51,7 @@ class UDP implements DriverInterface
     }
 
     /**
-     * {@inheritdoc }
+     * {@inheritdoc}
      */
     public function setParameters(array $parameters)
     {
@@ -59,7 +59,7 @@ class UDP implements DriverInterface
     }
 
     /**
-     * {@inheritdoc }
+     * {@inheritdoc}
      */
     public function getParameters()
     {
@@ -67,7 +67,7 @@ class UDP implements DriverInterface
     }
 
     /**
-     * {@inheritdoc }
+     * {@inheritdoc}
      */
     public function write($data = null)
     {
@@ -81,7 +81,7 @@ class UDP implements DriverInterface
     }
 
     /**
-     * {@inheritdoc }
+     * {@inheritdoc}
      */
     public function isSuccess()
     {

--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -78,7 +78,6 @@ class Point
      */
     public function __toString()
     {
-
         $string = $this->measurement;
 
         if (count($this->tags) > 0) {
@@ -225,7 +224,6 @@ class Point
      */
     private function isValidTimeStamp($timestamp)
     {
-
         // if the code is run on a 32bit system, loosely check if the timestamp is a valid numeric
         if (PHP_INT_SIZE == 4 && is_numeric($timestamp)) {
             return true;
@@ -244,7 +242,5 @@ class Point
         }
 
         return true;
-
-
     }
 }

--- a/tests/unit/AbstractTest.php
+++ b/tests/unit/AbstractTest.php
@@ -99,6 +99,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         $mock = new MockHandler([
             new Response(200, array(), $body),
             new Response(200, array(), $body),
+            new Response(200, array(), $body),
             new Response(400, array(), 'fault{'),
             new Response(400, array(), $body),
             new Response(400, array(), $body),

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -67,7 +67,8 @@ class ClientTest extends AbstractTest
         $bodyResponse = file_get_contents(dirname(__FILE__) . '/json/result.example.json');
         $httpMockClient = $this->buildHttpMockClient($bodyResponse);
 
-        $client->setDriver(new Guzzle($httpMockClient));
+        $guzzle = new Guzzle($httpMockClient);
+        $client->setDriver($guzzle);
 
         /** @var \InfluxDB\ResultSet $result */
         $result = $client->query('somedb', $query);
@@ -78,6 +79,8 @@ class ClientTest extends AbstractTest
         $this->assertEquals('somedb', $parameters['database']);
         $this->assertInstanceOf('\InfluxDB\ResultSet', $result);
 
+        $point = new Point('test', 1.0);
+
         $this->assertEquals(
             true,
             $client->write(
@@ -86,7 +89,19 @@ class ClientTest extends AbstractTest
                     'database' => 'influx_test_db',
                     'method' => 'post'
                 ],
-                [new Point('test', 1.0)]
+                (string) $point
+            )
+        );
+
+        $this->assertEquals(
+            true,
+            $client->write(
+                [
+                    'url' => 'http://localhost',
+                    'database' => 'influx_test_db',
+                    'method' => 'post'
+                ],
+                [(string) $point]
             )
         );
 

--- a/tests/unit/DatabaseTest.php
+++ b/tests/unit/DatabaseTest.php
@@ -4,11 +4,8 @@ namespace InfluxDB\Test;
 
 use InfluxDB\Client;
 use InfluxDB\Database;
-use InfluxDB\Driver\Guzzle;
 use InfluxDB\Point;
 use InfluxDB\ResultSet;
-use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
 
 class DatabaseTest extends AbstractTest
 {
@@ -148,6 +145,14 @@ class DatabaseTest extends AbstractTest
         );
 
         $this->assertEquals(true, $this->database->writePoints(array($point1, $point2)));
+
+        $payload = [
+            (string) $point1,
+            (string) $point2
+        ];
+
+        $this->assertEquals(true, $this->database->writePayload($payload));
+
 
         $this->mockClient->expects($this->once())
             ->method('write')


### PR DESCRIPTION
- Updating Influx Database with support for writing direct payloads results in over 5x performance increase when writing large Points/Payloads.

- Corresponding Docblock updates for improved thoroughness. 

- Cleaning up some extra spaces in Point.