### PR TITLE
Fix Notice when calling InfluxDB\Client::fromDSN without username or password

### DIFF
--- a/src/InfluxDB/Client.php
+++ b/src/InfluxDB/Client.php
@@ -293,8 +293,8 @@ class Client
         $client = new self(
             $connParams['host'],
             $connParams['port'],
-            $connParams['user'],
-            $connParams['pass'],
+            isset($connParams['user']) ? $connParams['user'] : '',
+            isset($connParams['pass']) ? $connParams['pass'] : '',
             $ssl,
             $verifySSL,
             $timeout


### PR DESCRIPTION
This resolves #50.