### PR TITLE
Fixed tag with Boolean/Null value trigger parse error

### DIFF
--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -54,7 +54,7 @@ class Point
         }
 
         $this->measurement = (string) $measurement;
-        $this->tags = $tags;
+        $this->setTags($tags);
         $fields = $additionalFields;
 
         if ($value !== null) {
@@ -122,6 +122,15 @@ class Point
      */
     public function setTags($tags)
     {
+        foreach ($tags as &$tag) {
+            if ($tag === '') {
+                $tag = '""';
+            } elseif (is_bool($tag)) {
+                $tag = ($tag ? "true" : "false");
+            } elseif (is_null($tag)) {
+                $tag = ("null");
+            }
+        }
         $this->tags = $tags;
     }
 
@@ -145,6 +154,8 @@ class Point
                 $field = $this->escapeFieldValue($field);
             } elseif (is_bool($field)) {
                 $field = ($field ? "true" : "false");
+            } elseif (is_null($field)) {
+                $field = ("null");
             }
         }
 

--- a/tests/unit/PointTest.php
+++ b/tests/unit/PointTest.php
@@ -84,6 +84,32 @@ class PointTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, (string) $point);
     }
 
+    public function testTagBooleanValueEscaping() {
+        $expected = 'instance,bool_tag=false,value_tag=value cpucount=10i,free=1i,test="string",bool=false,value=1.11';
+        $point = $this->getPoint(null);
+
+        $point->setTags(['bool_tag' => false, 'value_tag' => 'value']);
+
+        $this->assertEquals($expected, (string) $point);
+    }
+
+    public function testTagNullValueEscaping() {
+        $expected = 'instance,null_tag=null,value_tag=value cpucount=10i,free=1i,test="string",bool=false,value=1.11';
+        $point = $this->getPoint(null);
+
+        $point->setTags(['null_tag' => null, 'value_tag' => 'value']);
+
+        $this->assertEquals($expected, (string) $point);
+    }
+    public function testTagEmptyValueEscaping() {
+        $expected = 'instance,empty_tag="",whitespace=\ ,value_tag=value cpucount=10i,free=1i,test="string",bool=false,value=1.11';
+        $point = $this->getPoint(null);
+
+        $point->setTags(['empty_tag' => '', 'whitespace' => ' ', 'value_tag' => 'value']);
+
+        $this->assertEquals($expected, (string) $point);
+    }
+
     /**
      * Provide wrong timestamp value for testing.
      */


### PR DESCRIPTION
'instance,bool_tag=,value_tag=value cpucount=10i,free=1i,test="string",bool=false,value=1.11':