### PR TITLE
Deprecate IF NOT EXISTS clause in database creation

### DIFF
--- a/src/InfluxDB/Database.php
+++ b/src/InfluxDB/Database.php
@@ -82,18 +82,17 @@ class Database
      * Create this database
      *
      * @param  RetentionPolicy $retentionPolicy
-     * @param  bool            $createIfNotExists Only create the database if it does not yet exist
+     * @param  bool            $createIfNotExists Deprecated parameter - to be removed
      * @return ResultSet
      * @throws DatabaseException
      */
-    public function create(RetentionPolicy $retentionPolicy = null, $createIfNotExists = true)
+    public function create(RetentionPolicy $retentionPolicy = null, $createIfNotExists = false)
     {
+        if ($createIfNotExists) {
+            trigger_error('The $createIfNotExists parameter to Database::create is deprecated', E_USER_DEPRECATED);
+        }
         try {
-            $query = sprintf(
-                'CREATE DATABASE %s"%s"',
-                ($createIfNotExists ? 'IF NOT EXISTS ' : ''),
-                $this->name
-            );
+            $query = sprintf('CREATE DATABASE "%s"', $this->name);
 
             $this->query($query);
 

--- a/tests/unit/DatabaseTest.php
+++ b/tests/unit/DatabaseTest.php
@@ -82,21 +82,25 @@ class DatabaseTest extends AbstractTest
         new Database(null, $this->mockClient);
     }
 
+    /**
+     * @expectedException \PHPUnit_Framework_Error_Deprecated
+     */
+    public function testIfNotExistsDeprecation()
+    {
+        $this->database->create(null, true);
+    }
+
     public function testCreate()
     {
         // test create with retention policy
-        $this->database->create($this->getTestRetentionPolicy('influx_test_db'), true);
+        $this->database->create($this->getTestRetentionPolicy('influx_test_db'));
         $this->assertEquals(
             'CREATE RETENTION POLICY "influx_test_db" ON "influx_test_db" DURATION 1d REPLICATION 1 DEFAULT',
             Client::$lastQuery
         );
 
-        // test creating a database without create if not exists
-        $this->database->create(null, true);
-        $this->assertEquals('CREATE DATABASE IF NOT EXISTS "influx_test_db"', Client::$lastQuery);
-
-        // test creating a database without create if not exists
-        $this->database->create(null, false);
+        // test creating a database without parameters
+        $this->database->create(null);
         $this->assertEquals('CREATE DATABASE "influx_test_db"', Client::$lastQuery);
 
 
@@ -190,7 +194,7 @@ class DatabaseTest extends AbstractTest
 
         // test handling of reserved keywords in database name
         $database->create();
-        $this->assertEquals('CREATE DATABASE IF NOT EXISTS "stats"', Client::$lastQuery);
+        $this->assertEquals('CREATE DATABASE "stats"', Client::$lastQuery);
 
         $database->listRetentionPolicies();
         $this->assertEquals('SHOW RETENTION POLICIES ON "stats"', Client::$lastQuery);


### PR DESCRIPTION
As noted in https://github.com/influxdata/influxdb/issues/5707 InfluxDB itself does not support this syntax anymore and will raise a syntax error if attempted.

I swapped the default value of the parameter and added a `E_USER_DEPRECATED` notice when it's still being explicitly used.

Refs #67