### PR TITLE
Check if path index isset(), avoids a notice if it is not set

### DIFF
--- a/src/InfluxDB/Client.php
+++ b/src/InfluxDB/Client.php
@@ -283,7 +283,7 @@ class Client
         }
 
         $ssl = $modifier === 'https' ? true : false;
-        $dbName = $connParams['path'] ? substr($connParams['path'], 1) : null;
+        $dbName = isset($connParams['path']) ? substr($connParams['path'], 1) : null;
 
         $client = new self(
             $connParams['host'],


### PR DESCRIPTION
If `InfluxDB\Client::fromDSN()` is used, but no path is given a notice is generated:

```
Notice (8): Undefined index: path [ROOT/vendor/influxdb/influxdb-php/src/InfluxDB/Client.php, line 286]
```

This minor change avoids that notice being raised.