### PR TITLE
Replace costly array_merge calls with foreach + array operator

### DIFF
--- a/src/InfluxDB/ResultSet.php
+++ b/src/InfluxDB/ResultSet.php
@@ -70,7 +70,9 @@ class ResultSet
                 || (isset($serie['tags']) && array_intersect($tags, $serie['tags'])))
                 && isset($serie['values'])
             ) {
-                $points = array_merge($points, $this->getPointsFromSerie($serie));
+                foreach ($this->getPointsFromSerie($serie) as $point) {
+                    $points[] = $point;
+                }
             }
         }
 


### PR DESCRIPTION
For the same workload, array_merge takes around 24s, loop + array operator takes around 2s. 

Profiler outputs: 
array_merge: https://i.imgur.com/obOXg0t.png
array operator: https://i.imgur.com/51KjJdc.png