### PR TITLE
Username/password should be urlencoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ $database = InfluxDB\Client::fromDSN(sprintf('influxdb://user:pass@%s:%s/%s', $h
 $client = $database->getClient();
 ```
 
+**Important:** don't forget to `urlencode()` the password (and username for that matter) when using a DSN,
+especially if it contains non-alphanumeric characters. Not doing so might cause exceptions to be thrown.
+  
 ### Reading data
 
 To fetch records from InfluxDB you can do a query directly on a database:

--- a/src/InfluxDB/Client.php
+++ b/src/InfluxDB/Client.php
@@ -270,6 +270,11 @@ class Client
     public static function fromDSN($dsn, $timeout = 0, $verifySSL = false, $connectTimeout = 0)
     {
         $connParams = parse_url($dsn);
+
+        if ($connParams === false) {
+            throw new ClientException('Unable to parse the InfluxDB DSN');
+        }
+
         $schemeInfo = explode('+', $connParams['scheme']);
         $dbName = null;
         $modifier = null;
@@ -290,8 +295,8 @@ class Client
         $client = new self(
             $connParams['host'],
             $connParams['port'],
-            isset($connParams['user']) ? $connParams['user'] : '',
-            isset($connParams['pass']) ? $connParams['pass'] : '',
+            isset($connParams['user']) ? urldecode($connParams['user']) : '',
+            isset($connParams['pass']) ? urldecode($connParams['pass']) : '',
             $ssl,
             $verifySSL,
             $timeout,


### PR DESCRIPTION
When creating a Client object from a DSN, where the password part of the URL contains a `#`, an exception is thrown with the message "is not a valid scheme". This is actually caused by `parse_url` returning false if the URL is too malformed. If the password part is urlencoded before passing it to `Client::fromDSN`, the `parse_url` function is able to parse the URL. The username and password parts will need to be urldecoded before using them to instantiate a new Client object.

See [this PHP bugreport](https://bugs.php.net/bug.php?id=73754) for details about unencoded hashes in URLs passed to `parse_url` (spoiler: it's not a bug, it's a feature).

So, currently:
- `influxdb://user:pa#ss@localhost:8086/my_db` will cause exception to be thrown
- `influxdb://user:pa%23ss@localhost:8086/my_db` will result in `parse_url` successfully parse the DSN, but the password will be incorrect (`pa%23ss' will be passed)

This pull request:
- will make `Client::fromDSN` throw a more descriptive exception if `parse_url` fails to parse the DSN
- will `urldecode()` the username and password parts before using them to create a new Client object
- updates the README.md to remind users to urlencode the username and password parts of the DSN