### PR TITLE
Resultset improvements for multiquery results

### DIFF
--- a/src/InfluxDB/Driver/Guzzle.php
+++ b/src/InfluxDB/Driver/Guzzle.php
@@ -94,8 +94,17 @@ class Guzzle implements DriverInterface, QueryDriverInterface
 
         $raw = (string) $response->getBody();
 
-        return new ResultSet($raw);
+        return $this->asResultSet($raw);
+    }
 
+    /**
+     * @param $raw
+     * @return ResultSet
+     * @throws \InfluxDB\Client\Exception
+     */
+    protected function asResultSet($raw)
+    {
+        return new ResultSet($raw);
     }
 
     /**

--- a/src/InfluxDB/ResultSet.php
+++ b/src/InfluxDB/ResultSet.php
@@ -30,12 +30,20 @@ class ResultSet
     public function __construct($raw)
     {
         $this->rawResults = $raw;
-        $this->parsedResults = json_decode((string) $raw, true);
+        $this->parsedResults = json_decode((string)$raw, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new \InvalidArgumentException('Invalid JSON');
         }
 
+        $this->validate();
+    }
+
+    /**
+     * @throws ClientException
+     */
+    protected function validate()
+    {
         // There was an error in the query thrown by influxdb
         if (isset($this->parsedResults['error'])) {
             throw new ClientException($this->parsedResults['error']);

--- a/src/InfluxDB/ResultSet.php
+++ b/src/InfluxDB/ResultSet.php
@@ -58,8 +58,9 @@ class ResultSet
     /**
      * @return string
      */
-    public function getRaw() {
-      return $this->rawResults;
+    public function getRaw()
+    {
+        return $this->rawResults;
     }
 
     /**
@@ -75,8 +76,8 @@ class ResultSet
         $emptyArgsProvided = empty($metricName) && empty($tags);
         foreach ($series as $serie) {
             if (($emptyArgsProvided
-                || $serie['name'] === $metricName
-                || (isset($serie['tags']) && array_intersect($tags, $serie['tags'])))
+                    || $serie['name'] === $metricName
+                    || (isset($serie['tags']) && array_intersect($tags, $serie['tags'])))
                 && isset($serie['values'])
             ) {
                 foreach ($this->getPointsFromSerie($serie) as $point) {
@@ -94,31 +95,60 @@ class ResultSet
      * results is an array of objects, one for each query,
      * each containing the keys for a series
      *
-     * @throws Exception
+     * @param int $queryIndex which Nth query result to return. Use null as value if you want all result of multi query results
      * @return array $series
+     * @throws ClientException
      */
-    public function getSeries()
+    public function getSeries($queryIndex = 0)
     {
-        $series = array_map(
-            function ($object) {
-                if (isset($object['error'])) {
-                    throw new ClientException($object['error']);
-                }
+        $results = $this->parsedResults['results'];
 
-                return isset($object['series']) ? $object['series'] : [];
-            },
-            $this->parsedResults['results']
-        );
+        if ($queryIndex !== null && !array_key_exists($queryIndex, $results)) {
+            throw new \InvalidArgumentException('Invalid statement index provided');
+        }
 
-        return array_shift($series);
+        $queryResults = [];
+        foreach ($results as $index => $query) {
+            /**
+             * 'statement_id' was introduced in 1.2+ version so for backwards compatibility use array index for query index
+             * See difference:
+             *  1.2 -> https://docs.influxdata.com/influxdb/v1.2/guides/querying_data/
+             *  1.1 -> https://docs.influxdata.com/influxdb/v1.1/guides/querying_data/
+             */
+            $statementId = isset($query['statement_id']) ? $query['statement_id'] : $index;
+
+            if ($queryIndex === $statementId) {
+                return $this->extractQuery($query);
+            }
+
+            if ($queryIndex === null) {
+                $queryResults[$statementId] = $this->extractQuery($query);
+            }
+        }
+
+        return $queryResults;
+    }
+
+    private function extractQuery($statementSeries)
+    {
+        if (isset($statementSeries['error'])) {
+            throw new ClientException($statementSeries['error']);
+        }
+
+        return isset($statementSeries['series']) ? $statementSeries['series'] : [];
     }
 
     /**
+     * @param int $queryIndex which Nth query result to return. Defaults to first query.
      * @return mixed
+     * @throws ClientException
      */
-    public function getColumns()
+    public function getColumns($queryIndex = 0)
     {
-        return $this->getSeries()[0]['columns'];
+        if ($queryIndex === null) {
+            $queryIndex = 0;
+        }
+        return $this->getSeries($queryIndex)[0]['columns'];
     }
 
     /**

--- a/src/InfluxDB/ResultSet.php
+++ b/src/InfluxDB/ResultSet.php
@@ -76,8 +76,8 @@ class ResultSet
         $emptyArgsProvided = empty($metricName) && empty($tags);
         foreach ($series as $serie) {
             if (($emptyArgsProvided
-                    || $serie['name'] === $metricName
-                    || (isset($serie['tags']) && array_intersect($tags, $serie['tags'])))
+                || $serie['name'] === $metricName
+                || (isset($serie['tags']) && array_intersect($tags, $serie['tags'])))
                 && isset($serie['values'])
             ) {
                 foreach ($this->getPointsFromSerie($serie) as $point) {

--- a/tests/unit/ResultSetTest.php
+++ b/tests/unit/ResultSetTest.php
@@ -156,9 +156,7 @@ EOD;
 
     public function testGetDefaultResultFromMultiStatementQuery()
     {
-        $resultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
-
-        $series = $resultSet->getSeries();
+        $series = $this->multiQueryResultSet->getSeries();
 
         $this->assertTrue(is_array($series));
         $this->assertCount(1, $series);
@@ -167,9 +165,7 @@ EOD;
 
     public function testGetNthResultFromMultiStatementQuery()
     {
-        $resultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
-
-        $series = $resultSet->getSeries(1);
+        $series = $this->multiQueryResultSet->getSeries(1);
 
         $this->assertTrue(is_array($series));
         $this->assertCount(1, $series);
@@ -178,9 +174,7 @@ EOD;
 
     public function testGetAllResultsFromMultiStatementQuery()
     {
-        $resultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
-
-        $series = $resultSet->getSeries(null);
+        $series = $this->multiQueryResultSet->getSeries(null);
 
         $this->assertTrue(is_array($series));
         $this->assertCount(2, $series);
@@ -196,9 +190,7 @@ EOD;
      */
     public function testGetInvalidResultFromMultiStatementQuery()
     {
-        $resultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
-
-        $resultSet->getSeries(2);
+        $this->multiQueryResultSet->getSeries(2);
     }
 
     /**

--- a/tests/unit/ResultSetTest.php
+++ b/tests/unit/ResultSetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace InfluxDB\Test\unit;
 
 use InfluxDB\ResultSet;
@@ -6,13 +7,17 @@ use PHPUnit\Framework\TestCase;
 
 class ResultSetTest extends TestCase
 {
-    /** @var ResultSet  $resultSet*/
+    /** @var ResultSet $resultSet */
     protected $resultSet;
+
+    /** @var ResultSet $resultSet */
+    protected $multiQueryResultSet;
 
     public function setUp()
     {
         $resultJsonExample = file_get_contents(__DIR__ . '/json/result.example.json');
         $this->resultSet = new ResultSet($resultJsonExample);
+        $this->multiQueryResultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
     }
 
     /**
@@ -47,18 +52,15 @@ EOD;
      */
     public function testThrowsInfluxDBExceptionIfAnyErrorInSeries()
     {
+        new ResultSet(file_get_contents(__DIR__ . '/json/result-error.example.json'));
+    }
 
-        $errorResult = <<<EOD
-{
-    "results": [
-        {
-            "series": [],
-            "error": "There was an error after querying"
-        }
-    ]
-}
-EOD;
-        new ResultSet($errorResult);
+    public function testGetRaw()
+    {
+        $resultJsonExample = file_get_contents(__DIR__ . '/json/result.example.json');
+        $resultSet = new ResultSet($resultJsonExample);
+
+        $this->assertEquals($resultJsonExample, $resultSet->getRaw());
     }
 
     /**
@@ -99,6 +101,13 @@ EOD;
     public function testGetSeries()
     {
         $this->assertEquals(['time', 'value'], $this->resultSet->getColumns());
+    }
+
+    public function testGetSeriesFromMultiQuery()
+    {
+        $this->assertEquals(['time', 'value'], $this->multiQueryResultSet->getColumns(0));
+        $this->assertEquals(['time', 'value'], $this->multiQueryResultSet->getColumns(null));
+        $this->assertEquals(['time', 'count'], $this->multiQueryResultSet->getColumns(1));
     }
 
     /**
@@ -143,5 +152,69 @@ EOD;
 
         $this->assertTrue(is_array($points));
         $this->assertCount($expectedNumberOfPoints, $points);
+    }
+
+    public function testGetDefaultResultFromMultiStatementQuery()
+    {
+        $resultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
+
+        $series = $resultSet->getSeries();
+
+        $this->assertTrue(is_array($series));
+        $this->assertCount(1, $series);
+        $this->assertEquals('cpu_load_short', $series[0]['name']);
+    }
+
+    public function testGetNthResultFromMultiStatementQuery()
+    {
+        $resultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
+
+        $series = $resultSet->getSeries(1);
+
+        $this->assertTrue(is_array($series));
+        $this->assertCount(1, $series);
+        $this->assertEquals('cpu_load_long', $series[0]['name']);
+    }
+
+    public function testGetAllResultsFromMultiStatementQuery()
+    {
+        $resultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
+
+        $series = $resultSet->getSeries(null);
+
+        $this->assertTrue(is_array($series));
+        $this->assertCount(2, $series);
+        $this->assertEquals('cpu_load_short', $series[0][0]['name']);
+        $this->assertEquals('cpu_load_long', $series[1][0]['name']);
+    }
+
+    /**
+     * Throws Exception if invalid query index is given
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid statement index provided
+     */
+    public function testGetInvalidResultFromMultiStatementQuery()
+    {
+        $resultSet = new ResultSet(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'));
+
+        $resultSet->getSeries(2);
+    }
+
+    /**
+     * Throws Exception if Nth query resulted an error
+     *
+     * @expectedException \InfluxDB\Client\Exception
+     * @expectedExceptionMessage should trigger error
+     */
+    public function testGetErrorFromMultiStatementQuery()
+    {
+        $raw = json_decode(file_get_contents(__DIR__ . '/json/result-multi-query.example.json'), true);
+        unset($raw['results'][1]['series']);
+        $raw['results'][1]['error'] = 'should trigger error';
+
+        $resultSet = new ResultSet(json_encode($raw));
+
+        $resultSet->getSeries(1);
     }
 }

--- a/tests/unit/json/result-error.example.json
+++ b/tests/unit/json/result-error.example.json
@@ -1,0 +1,8 @@
+{
+  "results": [
+    {
+      "statement_id": 0,
+      "error": "not executed"
+    }
+  ]
+}

--- a/tests/unit/json/result-multi-query.example.json
+++ b/tests/unit/json/result-multi-query.example.json
@@ -1,0 +1,48 @@
+{
+  "results": [
+    {
+      "statement_id": 0,
+      "series": [
+        {
+          "name": "cpu_load_short",
+          "columns": [
+            "time",
+            "value"
+          ],
+          "values": [
+            [
+              "2015-01-29T21:55:43.702900257Z",
+              2
+            ],
+            [
+              "2015-01-29T21:55:43.702900257Z",
+              0.55
+            ],
+            [
+              "2015-06-11T20:46:02Z",
+              0.64
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "statement_id": 1,
+      "series": [
+        {
+          "name": "cpu_load_long",
+          "columns": [
+            "time",
+            "count"
+          ],
+          "values": [
+            [
+              "1970-01-01T00:00:00Z",
+              3
+            ]
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
1. multiquery 'statement_id' was introduced in 1.2+ version to InfluxDb results. So to support handling multiquery results query index is added to methods. For backwards compatibility first query result is used as default. 

See the difference:
* version 1.2 -> https://docs.influxdata.com/influxdb/v1.2/guides/querying_data/
* version 1.1 -> https://docs.influxdata.com/influxdb/v1.1/guides/querying_data/

Fixes #94


2. Added methods to help customize ResultSet returned from default driver (Guzzle). 
