### PR TITLE
add Curl driver and in it support Unix Domain Socket connection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         }
     },
     "suggest": {
-        "stefanotorresi/influxdb-php-async": "An asyncronous client for InfluxDB, implemented via ReactPHP."
+        "stefanotorresi/influxdb-php-async": "An asyncronous client for InfluxDB, implemented via ReactPHP.",
+        "ext-curl": "Curl extension, needed for Curl driver"
     },
     "scripts": {
         "test": "vendor/bin/phpunit",

--- a/src/InfluxDB/Driver/Curl.php
+++ b/src/InfluxDB/Driver/Curl.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace InfluxDB\Driver;
+
+
+use InfluxDB\ResultSet;
+
+class Curl implements DriverInterface, QueryDriverInterface
+{
+    /**
+     * request parameters
+     *
+     * @var array
+     */
+    private $parameters;
+
+    /**
+     * @var string
+     */
+    private $dsn;
+
+    /**
+     * Array of curl options
+     *
+     * @var array
+     */
+    private $options;
+
+    /** @var array */
+    protected $lastRequestInfo;
+
+    /**
+     * Build the Curl driver from a dsn
+     * Examples:
+     *
+     * http://localhost:8086
+     * https://localhost:8086
+     * unix:///var/run/influxdb/influxdb.sock
+     *
+     * @param string $dsn
+     * @param array $options options for curl requests. See http://php.net/manual/en/function.curl-setopt.php for available options
+     * @throws Exception
+     */
+    public function __construct($dsn, $options = [])
+    {
+        if (!extension_loaded('curl')) {
+            throw new Exception('Curl extension is not enabled!');
+        }
+
+        $this->dsn = $dsn;
+        if (strpos($dsn, 'unix://') === 0) {
+            if (PHP_VERSION_ID < 70007) {
+                throw new Exception('Unix domain sockets are supported since PHP version PHP 7.0.7. Current version: ' . PHP_VERSION);
+            }
+            $curlVersion = curl_version()['version'];
+            if (version_compare($curlVersion, '7.40.0', '<')) {
+                throw new Exception('Unix domain sockets are supported since curl version 7.40.0! Current curl version: ' . $curlVersion);
+            }
+            $options[CURLOPT_UNIX_SOCKET_PATH] = substr($dsn, 7);
+
+            $this->dsn = 'http://localhost';
+        }
+
+        $this->options = $options;
+    }
+
+    /**
+     * Called by the client write() method, will pass an array of required parameters such as db name
+     *
+     * will contain the following parameters:
+     *
+     * [
+     *  'database' => 'name of the database',
+     *  'url' => 'URL to the resource',
+     *  'method' => 'HTTP method used'
+     * ]
+     *
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * Send the data
+     *
+     * @param $data
+     * @throws Exception
+     *
+     * @return mixed
+     */
+    public function write($data = null)
+    {
+        $options = $this->getCurlOptions();
+        $options[CURLOPT_POST] = 1;
+        $options[CURLOPT_POSTFIELDS] = $data;
+
+
+        $this->execute($this->parameters['url'], $options);
+    }
+
+    /**
+     * Should return if sending the data was successful
+     *
+     * @return bool
+     * @throws Exception
+     */
+    public function isSuccess()
+    {
+        if (empty($this->lastRequestInfo)) {
+            return false;
+        }
+        $statusCode = $this->lastRequestInfo['http_code'];
+
+        if (!in_array($statusCode, [200, 204], true)) {
+            throw new Exception('Request failed with HTTP Code ' . $statusCode);
+        }
+
+        return true;
+    }
+
+    /**
+     * @return ResultSet
+     * @throws \InfluxDB\Client\Exception
+     */
+    public function query()
+    {
+        $response = $this->execute($this->parameters['url'], $this->getCurlOptions());
+        return new ResultSet($response);
+    }
+
+    protected function execute($url, $curlOptions = [])
+    {
+        $this->lastRequestInfo = null;
+        $ch = curl_init();
+
+        foreach ($curlOptions as $option => $value) {
+            curl_setopt($ch, $option, $value);
+        }
+
+        curl_setopt($ch, CURLOPT_URL, $this->dsn . '/' . $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+        $result = curl_exec($ch);
+        $this->lastRequestInfo = curl_getinfo($ch);
+
+        if ($result === false) {
+            // in case of total failure - socket/port is closed etc
+            throw new Exception('Request failed! curl_errno: ' . curl_errno($ch));
+        }
+
+
+        curl_close($ch);
+
+        return $result;
+    }
+
+    /**
+     * Returns curl options
+     *
+     * @return array
+     */
+    public function getCurlOptions()
+    {
+        $opts = $this->options + [
+                CURLOPT_CONNECTTIMEOUT => 5, // 5 seconds
+                CURLOPT_TIMEOUT => 10, // 30 seconds
+            ];
+
+        if (isset($this->parameters['auth'])) {
+            list($username, $password) = $this->parameters['auth'];
+            $opts[CURLOPT_USERPWD] = $username . ':' . $password;
+        }
+
+        return $opts;
+    }
+
+    /**
+     * Last curl request info
+     *
+     * @return array
+     */
+    public function getLastRequestInfo()
+    {
+        return $this->lastRequestInfo;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDsn()
+    {
+        return $this->dsn;
+    }
+}

--- a/tests/unit/Driver/CurlTest.php
+++ b/tests/unit/Driver/CurlTest.php
@@ -1,0 +1,236 @@
+<?php
+
+// mock namespace for unit tests to replace curl methods
+namespace InfluxDB\Driver {
+
+    function curl_init()
+    {
+        return null;
+    }
+
+    function curl_setopt($curl, $opt, $value)
+    {
+        \InfluxDB\Test\unit\Driver\CurlTest::$MOCK_OPTS[$opt] = $value;
+    }
+
+    function curl_exec()
+    {
+        return \InfluxDB\Test\unit\Driver\CurlTest::$MOCK_RESPONSE;
+    }
+
+    function curl_getinfo()
+    {
+        return \InfluxDB\Test\unit\Driver\CurlTest::$MOCK_INFO;
+    }
+
+    function curl_close()
+    {
+    }
+
+    function curl_errno()
+    {
+        return 999;
+    }
+}
+
+
+namespace InfluxDB\Test\unit\Driver {
+
+    use InfluxDB\Driver\Curl;
+    use InfluxDB\ResultSet;
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @requires extension curl
+     */
+    class CurlTest extends TestCase
+    {
+        static $MOCK_RESPONSE;
+        static $MOCK_OPTS;
+        static $MOCK_INFO;
+
+        public function setUp()
+        {
+            parent::setUp();
+
+            static::$MOCK_RESPONSE = false;
+            static::$MOCK_INFO = [];
+            static::$MOCK_OPTS = [];
+        }
+
+        protected function skipIsCurlTooOld()
+        {
+            $curlVersion = curl_version()['version'];
+            if (version_compare($curlVersion, '7.40.0', '<')) {
+                $this->markTestSkipped('Curl version is too low to support unix domain sockets. Version: ' . $curlVersion);
+            }
+        }
+
+        /**
+         * @requires PHP 7.0.7
+         */
+        public function testUnixDomainSocketDriverConstruction()
+        {
+            $this->skipIsCurlTooOld();
+            $driver = new Curl('unix:///var/run/influxdb/influxdb.sock');
+
+            $this->assertEquals('http://localhost', $driver->getDsn());
+            $this->assertArraySubset([CURLOPT_UNIX_SOCKET_PATH => '/var/run/influxdb/influxdb.sock'], $driver->getCurlOptions());
+
+        }
+
+        public function testHttpDriverConstruction()
+        {
+            $driver = new Curl('http://localhost:8086');
+
+            $this->assertEquals('http://localhost:8086', $driver->getDsn());
+            $this->assertArrayNotHasKey(10231, $driver->getCurlOptions());
+        }
+
+        public function testParameters()
+        {
+            $driver = new Curl('http://localhost:8086');
+
+            $parameters = ['auth' => ['user', 'password']];
+            $driver->setParameters($parameters);
+
+            $this->assertEquals($parameters, $driver->getParameters());
+        }
+
+        public function testGetCurlOptions()
+        {
+            $driver = new Curl('http://localhost:8086', [CURLOPT_USERAGENT => 'influxdb-php-lib']);
+
+            $this->assertEquals(
+                [
+                    CURLOPT_USERAGENT => 'influxdb-php-lib',
+                    CURLOPT_CONNECTTIMEOUT => 5,
+                    CURLOPT_TIMEOUT => 10,
+                ],
+                $driver->getCurlOptions()
+            );
+        }
+
+        public function testGetCurlOptionsAuth()
+        {
+            $driver = new Curl('http://localhost:8086', [CURLOPT_USERAGENT => 'influxdb-php-lib']);
+
+            $parameters = ['auth' => ['user', 'password']];
+            $driver->setParameters($parameters);
+
+            $this->assertEquals(
+                [
+                    CURLOPT_USERAGENT => 'influxdb-php-lib',
+                    CURLOPT_CONNECTTIMEOUT => 5,
+                    CURLOPT_TIMEOUT => 10,
+                    CURLOPT_USERPWD => 'user:password',
+                ],
+                $driver->getCurlOptions()
+            );
+        }
+
+        public function testQuery()
+        {
+            $driver = new Curl('http://localhost:8086', [CURLOPT_USERAGENT => 'influxdb-php-lib']);
+
+            static::$MOCK_INFO = ['http_code' => 200];
+            static::$MOCK_RESPONSE = file_get_contents(__DIR__ . '/../json/result.example.json');
+            $driver->setParameters(['url' => 'query?show measurements']);
+
+            $result = $driver->query();
+
+            $this->assertInstanceOf(ResultSet::class, $result);
+            $this->assertEquals(static::$MOCK_RESPONSE, $result->getRaw());
+            $this->assertEquals(static::$MOCK_INFO, $driver->getLastRequestInfo());
+
+            $this->assertArraySubset(
+                [
+                    CURLOPT_URL => 'http://localhost:8086/query?show measurements',
+                    CURLOPT_USERAGENT => 'influxdb-php-lib',
+                ],
+                static::$MOCK_OPTS
+            );
+        }
+
+        public function testWrite()
+        {
+            $driver = new Curl('http://localhost:8086');
+
+            static::$MOCK_INFO = ['http_code' => 200];
+            static::$MOCK_RESPONSE = '';
+            $driver->setParameters(['url' => 'write?something']);
+
+            $driver->write(['data']);
+
+            $this->assertArraySubset(
+                [
+                    CURLOPT_POST => 1,
+                    CURLOPT_POSTFIELDS => ['data'],
+                ],
+                static::$MOCK_OPTS
+            );
+            $this->assertTrue($driver->isSuccess());
+
+        }
+
+        /**
+         * @requires PHP 7.0.7
+         */
+        public function testWriteUnixDomainSocket()
+        {
+            $this->skipIsCurlTooOld();
+            $driver = new Curl('unix:///var/run/influxdb/influxdb.sock', [CURLOPT_USERAGENT => 'influxdb-php-lib']);
+
+            static::$MOCK_INFO = ['http_code' => 200];
+            static::$MOCK_RESPONSE = '';
+            $driver->setParameters(['url' => 'write?something']);
+
+            $driver->write(['data']);
+
+            $this->assertArraySubset(
+                [
+                    CURLOPT_UNIX_SOCKET_PATH => '/var/run/influxdb/influxdb.sock',
+                    CURLOPT_POST => 1,
+                    CURLOPT_POSTFIELDS => ['data'],
+                    CURLOPT_USERAGENT => 'influxdb-php-lib',
+                ],
+                static::$MOCK_OPTS
+            );
+            $this->assertTrue($driver->isSuccess());
+
+        }
+
+        /**
+         * @expectedException \InfluxDB\Driver\Exception
+         * @expectedExceptionMessage Request failed with HTTP Code 500
+         */
+        public function testIsSuccessThrowsExceptionOnHttpError()
+        {
+            $driver = new Curl('http://localhost:8086');
+
+            static::$MOCK_INFO = ['http_code' => 500];
+            static::$MOCK_RESPONSE = '';
+            $driver->setParameters(['url' => 'write?something']);
+
+            $driver->write(['data']);
+
+            $driver->isSuccess();
+        }
+
+        /**
+         * @expectedException \InfluxDB\Driver\Exception
+         * @expectedExceptionMessage Request failed! curl_errno: 999
+         */
+        public function testRequestThrowsExceptionWhenResultIsMissing()
+        {
+            $driver = new Curl('http://localhost:8086');
+
+            static::$MOCK_RESPONSE = false;
+            $driver->setParameters(['url' => 'write?something']);
+
+            $driver->write(['data']);
+        }
+
+    }
+}
+


### PR DESCRIPTION
Add support for [Curl](http://php.net/manual/en/book.curl.php) as a driver and support for [unix domain socket](https://docs.influxdata.com/influxdb/v1.6/administration/config/#unix-socket-enabled-false) connections (resolves #87)

Did not want to touch `Client::fromDSN` to support this. 

Currently to use UDS this is needed:
```
$client = new Client(null);
$client->setDriver(new Curl('unix:///var/run/influxdb/influxdb.sock'));
            
$db = new Database('myawesomedb', $client);
            
$resultSet = $db->query('show measurements');
```