### PR TITLE
Add tags data in point

### DIFF
--- a/src/InfluxDB/ResultSet.php
+++ b/src/InfluxDB/ResultSet.php
@@ -121,8 +121,14 @@ class ResultSet
     {
         $points = [];
 
-        foreach ($serie['values'] as $point) {
-            $points[] = array_combine($serie['columns'], $point);
+        foreach ($serie['values'] as $value) {
+            $point = array_combine($serie['columns'], $value);
+
+            if (isset($serie['tags'])) {
+                $point += $serie['tags'];
+            }
+
+            $points[] = $point;
         }
 
         return $points;


### PR DESCRIPTION
When using a GROUP BY on a tag, it's moved from the "values" list to the "tags" list (in the serie) and get ignored when converting it to point. So for example if you want the last memory usage for all your servers you would do something like : "SELECT last(value) FROM "memory_usage" GROUP BY "hostname", and you wouldn't have the hostname information in the final point data.
This commit adds the tags in the point to avoid this problem.