### PR TITLE
Native way to send http request in PHP

### DIFF
--- a/src/InfluxDB/Driver/PlainPhpHttp.php
+++ b/src/InfluxDB/Driver/PlainPhpHttp.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @author public@akademic.name
+ */
+
+namespace InfluxDB\Driver;
+
+use InfluxDB\ResultSet;
+
+/**
+ * Class PlainPhpHttp
+ *
+ * @package InfluxDB\Driver
+ */
+
+class PlainPhpHttp implements DriverInterface, QueryDriverInterface {
+
+    /**
+     * Array of options
+     *
+     * @var array
+     */
+    private $parameters;
+
+    /**
+     * @var string
+     */
+    private $baseUri;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * Set the config for this driver
+     *
+     * @param Client $client
+     *
+     */
+    public function __construct($baseUri) {
+        $this->baseUri = $baseUri;
+    }
+
+    /**
+     * Called by the client write() method, will pass an array of required parameters such as db name
+     *
+     * will contain the following parameters:
+     *
+     * [
+     *  'database' => 'name of the database',
+     *  'url' => 'URL to the resource',
+     *  'method' => 'HTTP method used'
+     * ]
+     *
+     * @param array $parameters
+     *
+     */
+    public function setParameters(array $parameters) {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters() {
+        return $this->parameters;
+    }
+
+    /**
+     * Send the data
+     *
+     * @param $data
+     *
+     * @throws \Exception
+     */
+    public function write($data = null) {
+        $full_url = $this->baseUri . '/' . $this->parameters['url'];
+        $body = $this->getRequestParameters($data)['body'];
+
+        $opts = [
+            'http' => [
+                'method' => 'POST',
+                'content' => $body
+            ]
+        ];
+
+        $context = stream_context_create($opts);
+
+        $result = file_get_contents($full_url, false, $context);
+        $this->response = new PlainPhpHttpResponse($http_response_header, $result);
+    }
+
+    /**
+     * @throws \Exception
+     * @return ResultSet
+     */
+    public function query() {
+        $full_url = $this->baseUri . '/' . $this->parameters['url'];
+        $result = file_get_contents($full_url);
+
+        return new ResultSet($result);
+    }
+
+    /**
+     * Should return if sending the data was successful
+     *
+     * @return bool
+     * @throws Exception
+     */
+    public function isSuccess() {
+        $statuscode = $this->response->getStatusCode();
+
+        if( !in_array($statuscode, [200, 204], true) ) {
+            throw new Exception('HTTP Code ' . $statuscode . ' ' . $this->response->getBody());
+        }
+
+        return true;
+    }
+
+    /**
+     * @param null $data
+     *
+     * @return array
+     */
+    protected function getRequestParameters($data = null) {
+        $requestParameters = ['http_errors' => false];
+
+        if( $data ) {
+            $requestParameters += ['body' => $data];
+        }
+
+        if( isset($this->parameters['auth']) ) {
+            $requestParameters += ['auth' => $this->parameters['auth']];
+        }
+
+        return $requestParameters;
+    }
+}

--- a/src/InfluxDB/Driver/PlainPhpHttp.php
+++ b/src/InfluxDB/Driver/PlainPhpHttp.php
@@ -85,6 +85,8 @@ class PlainPhpHttp implements DriverInterface, QueryDriverInterface {
             ]
         ];
 
+        $opts = $this->setupAuthHeader($opts);
+
         $context = stream_context_create($opts);
 
         $result = file_get_contents($full_url, false, $context);
@@ -97,7 +99,18 @@ class PlainPhpHttp implements DriverInterface, QueryDriverInterface {
      */
     public function query() {
         $full_url = $this->baseUri . '/' . $this->parameters['url'];
-        $result = file_get_contents($full_url);
+
+        $opts = [
+            'http' => [
+                'method' => 'GET',
+            ]
+        ];
+
+        $opts = $this->setupAuthHeader($opts);
+
+        $context = stream_context_create($opts);
+
+        $result = file_get_contents($full_url, false, $context);
 
         return new ResultSet($result);
     }
@@ -135,5 +148,14 @@ class PlainPhpHttp implements DriverInterface, QueryDriverInterface {
         }
 
         return $requestParameters;
+    }
+
+    protected function setupAuthHeader($opts) {
+        if( isset($this->parameters['auth']) ) {
+            $auth_hash = base64_encode(implode(':', $this->parameters['auth']));
+            $opts['http']['header'] = 'Authorization: Basic ' . $auth_hash;
+        }
+
+        return $opts;
     }
 }

--- a/src/InfluxDB/Driver/PlainPhpHttpResponse.php
+++ b/src/InfluxDB/Driver/PlainPhpHttpResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace InfluxDB\Driver;
+
+class PlainPhpHttpResponse {
+
+    private $result_headers = [];
+    private $body = [];
+
+    function __construct($result_headers, $body) {
+        $this->body = $body;
+        $this->result_headers = $result_headers;
+    }
+
+    function getStatusCode() {
+        if( is_array($this->result_headers) ) {
+            $a = explode(' ', $this->result_headers[0]);
+
+            if( count($a) > 1 ) {
+                return intval($a[1]);
+            }
+        }
+
+        return 0;
+    }
+
+    function getBody() {
+        return $this->body;
+    }
+}


### PR DESCRIPTION
I was unpleasantly surprised when I've realized that I need composer to install influxdb driver.
influxdb-php depends on external code like Guzzle and uses very little functionality of it.
I believe that drivers should be installed by coping files or with only git clone command.

This PoC implementation based on file_get_contents function for writing and querying data.
Probably I should rewrite this code to allow testing with mocks. Let me know if it nessesary.

Now I suggest only optional driver.
But I suppose it can be default way to use influxdb over http after more testing.

```
$client = new InfluxDB\Client('127.0.0.1', 8086);
$client->setDriver(new InfluxDB\Driver\PlainPhpHttp($client->getBaseURI()));
```