### PR TITLE
Escape backslashes in point values

### DIFF
--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -204,7 +204,13 @@ class Point
      */
     private function escapeFieldValue($value)
     {
-        $escapedValue = str_replace('"', '\"', $value);
+        $escapedValue = str_replace([
+            '\\',
+            '"'
+        ],[
+            '\\\\',
+            '\"'
+        ], $value);
         return sprintf('"%s"', $escapedValue);
     }
 

--- a/tests/unit/PointTest.php
+++ b/tests/unit/PointTest.php
@@ -96,10 +96,10 @@ class PointTest extends TestCase
 
     public function testFieldValueStringEscaping()
     {
-        $expected = 'instance,host=server01,region=us-west spaces="string with spaces",doublequote="the \" is escaped"';
+        $expected = 'instance,host=server01,region=us-west spaces="string with spaces",doublequote="the \" is escaped",backslash="the \\\\ is escaped"';
         $point = $this->getPoint(null);
 
-        $point->setFields(['spaces' => 'string with spaces', 'doublequote' => 'the " is escaped']);
+        $point->setFields(['spaces' => 'string with spaces', 'doublequote' => 'the " is escaped', 'backslash' => 'the \\ is escaped']);
 
         $this->assertEquals($expected, (string) $point);
     }


### PR DESCRIPTION
Unescaped backslashes should only cause a problem if they immediately
preceed a dobule quote, or if they're the last character in the value,
but we escape them all, just to be safe.