### PR TITLE
Fix a phpdoc annotation in the Point class

### DIFF
--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -36,7 +36,7 @@ class Point
      * local timestamp will be used
      *
      * @param  string $measurement
-     * @param  float  $value
+     * @param  ?float $value
      * @param  array  $tags
      * @param  array  $additionalFields
      * @param  int    $timestamp


### PR DESCRIPTION
Running phan(a static analyzer for PHP) results in the following error:

```
PhanTypeMismatchArgument Argument 2 (value) is null but \InfluxDB\Point::__construct() takes float defined at vendor/influxdb/influxdb-php/src/InfluxDB/Point.php:45
```

This pull request fix it.