### PR TITLE
Fix locale floats

### DIFF
--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -235,9 +235,13 @@ class Point
     {
         $strParts = [];
 
+        $origLocale = setlocale(LC_NUMERIC, 0);
+        // Use the POSIX locale which defines the `decimal_point` separator as `.`
+        setlocale(LC_NUMERIC, 'POSIX');
         foreach ($arr as $key => $value) {
             $strParts[] = sprintf('%s=%s', $key, $value);
         }
+        setlocale(LC_NUMERIC, $origLocale);
 
         return implode(',', $strParts);
     }

--- a/tests/unit/PointTest.php
+++ b/tests/unit/PointTest.php
@@ -18,6 +18,25 @@ class PointTest extends TestCase
     }
 
     /**
+     * Check that locales that use a non-dot separator sends a valid line format
+     */
+    public function testPointLocaleStringRepresentation()
+    {
+        $origLocale = setlocale(LC_ALL, 0);
+        // `de_DE` uses a comma `decimal_point` separator, ie `(string)1.11` becomes `"1,11"`
+        setlocale(LC_ALL, 'de_DE');
+
+        $expected = 'instance,host=server01,region=us-west cpucount=10i,free=1i,test="string",bool=false,value=1.11 1440494531376778481';
+
+        $point = $this->getPoint('1440494531376778481');
+
+        $stringPoint = (string)$point;
+        setlocale(LC_ALL, $origLocale);
+
+        $this->assertEquals($expected, $stringPoint);
+    }
+
+    /**
      * Check if the Point class throw an exception when invalid timestamp are given.
      *
      * @dataProvider wrongTimestampProvider


### PR DESCRIPTION
When running under locales with a non-`.` `decimal_point` separator, PHP generates a bad line protocol string.

For example:

```php
require 'vendor/autoload.php';

$p = new InfluxDB\Point('foo', 1.11, [], ['bar' => 'baz']);

setlocale(LC_ALL, 'en_US');
echo (string) $p . PHP_EOL;

setlocale(LC_ALL, 'de_DE');
echo (string) $p . PHP_EOL;
```

Results in two different lines:

```
foo bar="baz",value=1.11
foo bar="baz",value=1,11
```

This change adds test coverage for this scenario and resolves the issue by ensuring a `.` `decimal_point` separator compatible locale is used at time of string casting.