### PR TITLE
Added ability to iterate over large queries without exceeding memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $client = $database->getClient();
 
 **Important:** don't forget to `urlencode()` the password (and username for that matter) when using a DSN,
 especially if it contains non-alphanumeric characters. Not doing so might cause exceptions to be thrown.
-  
+
 ### Reading data
 
 To fetch records from InfluxDB you can do a query directly on a database:
@@ -101,6 +101,16 @@ In production if you are querying InfluxDB to generate a response to a web or AP
 ```php
 // Fetch the database using a 5 second time out
 $database = InfluxDB\Client::fromDSN(sprintf('influxdb://user:pass@%s:%s/%s', $host, $port, $dbname), 5);
+```
+
+### Reading large data sets
+
+Reading large data sets may exceed available memory. To overcome this obstacle, use the iterate() method to return each point without loading them all first into memory.  This method supports only a single measurement, however, you can manually target another measurement if necessary.
+
+```php
+foreach($result->iterate() as $index=>$point) {
+    // Process each $point as needed.
+}
 ```
 
 ### Writing data
@@ -280,6 +290,27 @@ $result = $client->listUsers();
 $result = $client->listDatabases();
 ```
 
+### Other Database functions
+
+Several additional database functions are available:
+
+```php
+// list measurements
+$result = $database->listMeasurements();
+
+// list all field keys
+$result = $database->listFieldKeys();
+
+// list field keys for a single measurement
+$result = $database->listFieldKeys('yourMeasurement');
+
+// list all tag keys
+$result = $database->listTagKeys();
+
+// list tag keys for a single measurement
+$result = $database->listTagKeys('yourMeasurement');
+```
+
 ### Admin functionality
 
 You can use the client's $client->admin functionality to administer InfluxDB via the API.
@@ -371,10 +402,10 @@ $client->admin->revoke(\InfluxDB\Client\Admin::PRIVILEGE_ALL, 'admin_user');
 * Fixed tag with Boolean/Null value trigger parse error
 
 #### 1.4.1
-* Fixed bug: Escape field values as per line protocol. 
+* Fixed bug: Escape field values as per line protocol.
 
 #### 1.4.0
-* Updating Influx Database with support for writing direct payloads, thanks @virgofx 
+* Updating Influx Database with support for writing direct payloads, thanks @virgofx
 
 #### 1.3.1
 * Added ability to write data to a specific retention policy, thanks @virgofx !

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
+        "halaxa/json-machine": "0.3.2",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {

--- a/src/InfluxDB/Client.php
+++ b/src/InfluxDB/Client.php
@@ -349,6 +349,7 @@ class Client
     public function setDriver(DriverInterface $driver)
     {
         $this->driver = $driver;
+        return $this;
     }
 
     /**

--- a/src/InfluxDB/Database.php
+++ b/src/InfluxDB/Database.php
@@ -206,6 +206,63 @@ class Database
     }
 
     /**
+     * @return array
+     */
+    public function listMeasurements():array
+    {
+        return array_map(function($m){
+            return $m[0];
+        }, $this->query('SHOW MEASUREMENTS')->getSeries()[0]['values']);
+    }
+
+    /**
+     * @param $measurement
+     * @return array
+     * @throws Exception
+     */
+    public function listFieldKeys(?string $measurement=null):array
+    {
+        $rs = $measurement
+        ?$this->query(sprintf('SHOW FIELD KEYS FROM "%s"', $measurement))->getSeries()
+        :$this->query('SHOW FIELD KEYS')->getSeries();
+        $arr=[];
+        foreach($rs as $m) {
+            $arr[$m['name']]=[];
+            foreach($m['values'] as $v) {
+                $arr[$m['name']][$v[0]]=$v[1];
+            }
+        }
+        if($measurement) {
+            if(!isset($arr[$measurement])) throw new Exception("Measurement $measurement does not exist.");
+            return $arr[$measurement];
+        }
+        else return $arr;
+    }
+
+    /**
+     * @param $measurement
+     * @return array
+     * @throws Exception
+     */
+    public function listTagKeys(?string $measurement=null):array
+    {
+        $rs = $measurement
+        ?$this->query(sprintf('SHOW TAG KEYS FROM "%s"', $measurement))->getSeries()
+        :$this->query('SHOW TAG KEYS')->getSeries();
+        $arr=[];
+        foreach($rs as $m) {
+            $arr[$m['name']]=array_map(function($v){
+                return $v[0];
+                }, $m['values']);
+        }
+        if($measurement) {
+            if(!isset($arr[$measurement])) throw new Exception("Measurement $measurement does not exist.");
+            return $arr[$measurement];
+        }
+        else return $arr;
+    }
+
+    /**
      * Drop this database
      */
     public function drop()

--- a/src/InfluxDB/Driver/Guzzle.php
+++ b/src/InfluxDB/Driver/Guzzle.php
@@ -7,6 +7,7 @@ namespace InfluxDB\Driver;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\StreamWrapper;
 use InfluxDB\ResultSet;
 
 /**
@@ -86,25 +87,13 @@ class Guzzle implements DriverInterface, QueryDriverInterface
 
     /**
      * @throws \Exception
-     * @return ResultSet
+     * @return stream
      */
     public function query()
     {
         $response = $this->httpClient->get($this->parameters['url'], $this->getRequestParameters());
 
-        $raw = (string) $response->getBody();
-
-        return $this->asResultSet($raw);
-    }
-
-    /**
-     * @param $raw
-     * @return ResultSet
-     * @throws \InfluxDB\Client\Exception
-     */
-    protected function asResultSet($raw)
-    {
-        return new ResultSet($raw);
+        return new ResultSet(StreamWrapper::getResource($response->getBody()));
     }
 
     /**

--- a/src/InfluxDB/Driver/QueryDriverInterface.php
+++ b/src/InfluxDB/Driver/QueryDriverInterface.php
@@ -16,7 +16,8 @@ interface QueryDriverInterface
 {
 
     /**
-     * @return ResultSet
+     * @throws \Exception
+     * @return stream
      */
     public function query();
 }


### PR DESCRIPTION
Thanks for your work creating influxdb-php.

I had the need to perform very large queries and process the data, however, memory limitations prevented me from doing so.  One is now able to do so without any regard to PHP memory.  It is accomplished by using https://github.com/halaxa/json-machine.  Per their documentation, it might be higher performing that json_encode() and I originally intended to use it with the standard query() method as well, however, my initial testing did not seem to indicate so.

Thanks, Michael