### PR TITLE
Add support for Guzzle client version 7.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
The Guzzle API for versions 6.x and 7.x are very similar, so much so that in the case of this library the only requirement should be simply to add support for it.