### PR TITLE
[PHP 8.1] Fixed argument type mismatch

### DIFF
--- a/src/InfluxDB/Driver/UDP.php
+++ b/src/InfluxDB/Driver/UDP.php
@@ -75,6 +75,10 @@ class UDP implements DriverInterface
             $this->createStream();
         }
 
+        if (!is_resource($this->stream)) {
+            return true;
+        }
+
         @stream_socket_sendto($this->stream, $data);
 
         return true;


### PR DESCRIPTION
fixed "Argument #1 ($socket) must be of type resource, bool given".

whenever a stream could not be created the property was still passed to `stream_socket_sendto` which causes an type error in php 8.1.